### PR TITLE
Fix imperative return causing transition to hang

### DIFF
--- a/lib/components/createRouter.js
+++ b/lib/components/createRouter.js
@@ -28,12 +28,14 @@ export default function createRouter () {
     },
 
     installRenderMiddleware: function (router) {
-      let render = transition => transition.then(() =>
-        this.setState({
-          routes: transition.routes,
-          params: transition.params
-        })
-      )
+      let render = transition => {
+        transition.then(() =>
+          this.setState({
+            routes: transition.routes,
+            params: transition.params
+          })
+        )
+      }
       router.use(render)
     },
 


### PR DESCRIPTION
The arrow function's imperative return was causing the result of `transition.then` to be returned from the middleware, creating a never-resolving promise.

Oops...
