### PR TITLE
Reference correct attribute in router params initial state

### DIFF
--- a/lib/components/createRouter.js
+++ b/lib/components/createRouter.js
@@ -20,7 +20,7 @@ export default function createRouter () {
       return {
         router: this.props.router,
         routes: this.props.router.state.routes || [],
-        params: this.props.router.state.routes || {},
+        params: this.props.router.state.params || {},
         query: this.props.router.state.query || {},
         // hacky?
         routerAlreadyStarted: !!this.props.router.state.routes


### PR DESCRIPTION
Also curious: are params ever defined initially in the cherrytree router?
